### PR TITLE
Do not complain if name does not match .1-001 format

### DIFF
--- a/Hum/Ace/SubSeq.pm
+++ b/Hum/Ace/SubSeq.pm
@@ -1331,7 +1331,9 @@ sub error_no_evidence {
                 $err .= "Transcript name does not begin with locus name '$locus_name'\n";
             }
         } else {
-            $err .= "Transcript name does not end in '.#-###' format\n";
+            if ($name !~ /^[^-]+-\d{3}$/) {
+              $err .= "Transcript name does not end in '.#-###' format\n";
+            }
         }
 
         my ($trsct_pre) = $name         =~ /$pre_pat/;


### PR DESCRIPTION
The .1-001 format was used when creating clone based
name. This names won't be created anymore so the check
is not needed anymore